### PR TITLE
Iter4

### DIFF
--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+)
+
+func main() {
+	endpoint := "http://localhost:8080/"
+	// контейнер данных для запроса
+	data := url.Values{}
+	// приглашение в консоли
+	fmt.Println("Введите длинный URL")
+	// открываем потоковое чтение из консоли
+	reader := bufio.NewReader(os.Stdin)
+	// читаем строку из консоли
+	long, err := reader.ReadString('\n')
+	if err != nil {
+		panic(err)
+	}
+	long = strings.TrimSuffix(long, "\n")
+	// заполняем контейнер данными
+	data.Set("url", long)
+	// добавляем HTTP-клиент
+	client := &http.Client{}
+	// пишем запрос
+	// запрос методом POST должен, помимо заголовков, содержать тело
+	// тело должно быть источником потокового чтения io.Reader
+	request, err := http.NewRequest(http.MethodPost, endpoint, strings.NewReader(data.Encode()))
+	if err != nil {
+		panic(err)
+	}
+	// в заголовках запроса указываем кодировку
+	request.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	// отправляем запрос и получаем ответ
+	response, err := client.Do(request)
+	if err != nil {
+		panic(err)
+	}
+	// выводим код ответа
+	fmt.Println("Статус-код ", response.Status)
+	defer response.Body.Close()
+	// читаем поток из тела ответа
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		panic(err)
+	}
+	// и печатаем его
+	fmt.Println(string(body))
+}

--- a/cmd/shortener/config/config.go
+++ b/cmd/shortener/config/config.go
@@ -1,0 +1,27 @@
+package config
+
+import (
+	"flag"
+	"fmt"
+)
+
+type Config struct {
+	Address string
+	BaseURL string
+}
+
+func LoadConfig() (*Config, error) {
+	address := flag.String("a", "localhost:8080", "HTTP server address")
+	baseURL := flag.String("b", "http://localhost:8080", "Base URL for shortened links")
+
+	flag.Parse()
+
+	if *address == "" || *baseURL == "" {
+		return nil, fmt.Errorf("address and base URL must be provided")
+	}
+
+	return &Config{
+		Address: *address,
+		BaseURL: *baseURL,
+	}, nil
+}

--- a/cmd/shortener/main.go
+++ b/cmd/shortener/main.go
@@ -1,3 +1,97 @@
 package main
 
-func main() {}
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/achufistov/shortygopher.git/cmd/shortener/config"
+
+	"github.com/go-chi/chi/v5"
+)
+
+var (
+	urlMap = make(map[string]string)
+	cfg    *config.Config
+)
+
+func main() {
+	var err error
+	cfg, err = config.LoadConfig()
+	if err != nil {
+		log.Fatalf("Error loading config: %v", err)
+	}
+
+	r := chi.NewRouter()
+
+	r.Post("/", handlePost)
+	r.Get("/{id}", handleGet)
+
+	log.Printf("Server is running on %s", cfg.Address)
+	log.Fatal(http.ListenAndServe(cfg.Address, r))
+}
+
+func handlePost(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Invalid request method", http.StatusBadRequest)
+		return
+	}
+
+	originalURL, err := readBody(r)
+	if err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	shortURL := generateShortURL()
+	urlMap[shortURL] = originalURL
+
+	w.Header().Set("Content-Type", "text/plain")
+	w.WriteHeader(http.StatusCreated)
+	fmt.Fprintf(w, "%s/%s", cfg.BaseURL, shortURL)
+}
+
+func handleGet(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Invalid request method", http.StatusBadRequest)
+		return
+	}
+
+	id := chi.URLParam(r, "id")
+	originalURL, exists := urlMap[id]
+
+	if !exists {
+		http.Error(w, "URL not found", http.StatusNotFound)
+		return
+	}
+
+	w.Header().Set("Location", originalURL)
+	w.WriteHeader(http.StatusTemporaryRedirect)
+}
+
+func readBody(r *http.Request) (string, error) {
+	if !strings.Contains(r.Header.Get("Content-Type"), "text/plain") {
+		return "", errors.New("invalid content type")
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return "", err
+	}
+
+	return string(body), nil
+}
+
+func generateShortURL() string {
+	b := make([]byte, 6)
+	_, err := rand.Read(b)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return base64.URLEncoding.EncodeToString(b)[:6]
+}

--- a/cmd/shortener/main_test.go
+++ b/cmd/shortener/main_test.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/achufistov/shortygopher.git/cmd/shortener/config"
+	"github.com/go-chi/chi/v5"
+)
+
+func initConfig() {
+	var err error
+	cfg, err = config.LoadConfig()
+	if err != nil {
+		panic(err) // nil pointer dereference fix in tests
+	}
+}
+
+func Test_handlePost(t *testing.T) {
+	initConfig()
+
+	tests := []struct {
+		name           string
+		requestBody    string
+		expectedStatus int
+		expectedURL    string
+	}{
+		{
+			name:           "Valid POST request",
+			requestBody:    "https://example.com",
+			expectedStatus: http.StatusCreated,
+			expectedURL:    "http://localhost:8080/",
+		},
+		{
+			name:           "Invalid content type",
+			requestBody:    "https://example.com",
+			expectedStatus: http.StatusBadRequest,
+			expectedURL:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := http.NewRequest("POST", "/", bytes.NewBufferString(tt.requestBody))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if tt.expectedStatus == http.StatusCreated {
+				req.Header.Set("Content-Type", "text/plain")
+			}
+
+			rr := httptest.NewRecorder()
+			handler := http.HandlerFunc(handlePost)
+
+			handler.ServeHTTP(rr, req)
+
+			if status := rr.Code; status != tt.expectedStatus {
+				t.Errorf("handler returned wrong status code: got %v want %v",
+					status, tt.expectedStatus)
+			}
+
+			if tt.expectedStatus == http.StatusCreated {
+				if !strings.HasPrefix(rr.Body.String(), tt.expectedURL) {
+					t.Errorf("handler returned unexpected body: got %v want %v",
+						rr.Body.String(), tt.expectedURL)
+				}
+			}
+		})
+	}
+}
+
+func Test_handleGet(t *testing.T) {
+	// Prepopulate the urlMap with a test URL
+	shortURL := "abc123"
+	originalURL := "https://example.com"
+	urlMap[shortURL] = originalURL
+
+	tests := []struct {
+		name           string
+		urlPath        string
+		expectedStatus int
+		expectedURL    string
+	}{
+		{
+			name:           "Valid GET request",
+			urlPath:        "/" + shortURL,
+			expectedStatus: http.StatusTemporaryRedirect,
+			expectedURL:    originalURL,
+		},
+		{
+			name:           "Invalid GET request",
+			urlPath:        "/nonexistent",
+			expectedStatus: http.StatusNotFound,
+			expectedURL:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := http.NewRequest("GET", tt.urlPath, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			rr := httptest.NewRecorder() // this test broke in the third increment
+			r := chi.NewRouter()         // to fix this problem, I used the chi router in this test so that the URL parameters were extracted correctly
+			r.Get("/{id}", handleGet)    // I've left the HandlerFunc() for the POST request in the same form so far
+
+			r.ServeHTTP(rr, req)
+
+			if status := rr.Code; status != tt.expectedStatus {
+				t.Errorf("handler returned wrong status code: got %v want %v",
+					status, tt.expectedStatus)
+			}
+
+			if tt.expectedStatus == http.StatusTemporaryRedirect {
+				if location := rr.Header().Get("Location"); location != tt.expectedURL {
+					t.Errorf("handler returned unexpected Location header: got %v want %v",
+						location, tt.expectedURL)
+				}
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/achufistov/shortygopher.git
+
+go 1.22.1
+
+require github.com/go-chi/chi/v5 v5.2.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/go-chi/chi/v5 v5.2.1 h1:KOIHODQj58PmL80G2Eak4WdvUzjSJSm0vG72crDCqb8=
+github.com/go-chi/chi/v5 v5.2.1/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=


### PR DESCRIPTION
Создана конфигурация для запуска со следующими флагами:

1. Флаг -a отвечает за адрес запуска HTTP-сервера (значение может быть таким: localhost:8888).
2. Флаг -b отвечает за базовый адрес результирующего сокращённого URL (значение: адрес сервера перед коротким URL, например http://localhost:8000/qsd54gFg).